### PR TITLE
Bump CMake version

### DIFF
--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -37,7 +37,7 @@ RUN \
 	rm ./*.deb
 
 # Setup newer CMake
-ENV CMAKEVER=3.15.7
+ENV CMAKEVER=3.16.9
 RUN \
 	curl -sLO https://cmake.org/files/v${CMAKEVER%.*}/cmake-${CMAKEVER}-Linux-x86_64.sh && \
 	sh cmake-${CMAKEVER}-Linux-x86_64.sh --skip-license && \


### PR DESCRIPTION
Linux build complains about
`Your CMake version is 3.15.7. Update to at least 3.16 to enable precompiled headers to speed up incremental builds`
This PR bumps CMake to 3.16.9.